### PR TITLE
Update multimodal-demo.ipynb: changed langchain version

### DIFF
--- a/multimodal-demo.ipynb
+++ b/multimodal-demo.ipynb
@@ -36,7 +36,7 @@
     "%%writefile demo-requirements.txt\n",
     "anthropic==0.2.10\n",
     "boto3\n",
-    "langchain==0.0.246\n",
+    "langchain==0.0.224\n",
     "PyAthena[SQLAlchemy]==2.25.2\n",
     "sqlalchemy==1.4.47\n",
     "pandas<2.0.0\n",


### PR DESCRIPTION
Changed to langchain ver 0.0.224, as the previously specified 0.0.246 is not compatible with anthropic version 0.2.10

*Issue #, if available:*

#7 

*Description of changes:*

Changed langchain version to 0.0.224 for compatibility with anthropic 0.2.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
