### PR TITLE
Update multimodal-demo.ipynb: fixed incorrect code

### DIFF
--- a/multimodal-demo.ipynb
+++ b/multimodal-demo.ipynb
@@ -747,7 +747,7 @@
     "    response=lambda_client.invoke(FunctionName='FSI-SentimentDetecttion',\n",
     "                        InvocationType='RequestResponse',\n",
     "                     Payload=json.dumps(inputString))\n",
-    "    output=json.loads(response['Payload'],read().decode())\n",
+    "    output=json.loads(response['Payload'].read().decode())\n",
     "    return output['body']\n",
     "\n",
     "def DetectKeyPhrases(inputString):\n",
@@ -757,7 +757,7 @@
     "    response=lambda_client.invoke(FunctionName='FSI-KeyPhrasesDetection',\n",
     "                        InvocationType='RequestResponse',\n",
     "                     Payload=json.dumps(inputString))\n",
-    "    output=json.loads(response['Payload'],read().decode())\n",
+    "    output=json.loads(response['Payload'].read().decode())\n",
     "    return output['body']\n"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

The functions:
- `SentimentAnalysis()`
- `DetectKeyPhrases()`

both contained the erroneous line:
```
output=json.loads(response['Payload'],read().decode())
```
which caused a runtime error.


*Description of changes:*

This has been corrected to use a `.` instead of a `,` as follows:
```
output=json.loads(response['Payload'].read().decode())
```
After this correction, the code now runs correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
