### PR TITLE
Update README.md: Fixed git clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Copy and paste the following command lines to pull the code from Github.
 
 ```
 cd SageMaker
-git init
-git clone git@github.com:aws-samples/aiml-genai-multimodal-agent.git
+git clone https://github.com/aws-samples/aiml-genai-multimodal-agent.git
 ```
 Then open *aiml-genai-multimodal-agent/multimodal-demo.ipynb* Python Notebook. This Notebook has the code to run the solution, as well as explanations of each step. 
 


### PR DESCRIPTION
*Description of changes:*

The current git clone instructions do not work as they rely on ssh, and there is no ssh key installed on the notebook. There is also a redundant  `git init` which is not needed.

Fixed the instructions to use https instead of ssh.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
